### PR TITLE
Added video download and conversion for playback in Godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,30 @@ print("Download completed !")
 
 ### Downloading a video and playing it in using a `VideoPlayer`
 
-Soon possible, see: <https://github.com/godotengine/godot-proposals/issues/3286>
+Possible, but very ineffecient!
+
+Currently the addon is downloading the video as a webm file and then converting it to an ogv file. 
+For the example video this means a 4x file size increase and a conversion of several minutes.
+
+Currently this is caused by a lack of video support in Godot.
+Please see <https://docs.godotengine.org/en/stable/tutorials/animation/playing_videos.html#supported-playback-formats> for more information.
+Godot is working on a better solution here: <https://github.com/godotengine/godot-proposals/issues/3286>
+
+```gdscript
+var download := YtDlp.download("https://youtu.be/Ya5Fv6VTLYM") \
+    .set_destination("user://video/") \
+    .set_file_name("ok_computer") \
+    .convert_to_video(YtDlp.Video.OGV) \
+    .start()
+
+await download.download_completed
+
+var stream = VideoStreamTheora.new()
+stream.file = "user://video/ok_computer.ogv"
+
+%VideoStreamPlayer.stream = stream
+%VideoStreamPlayer.play()
+```
 
 ### Downloading a video as audio and playing it using an `AudioStreamPlayer`
 

--- a/src/yt_dlp.gd
+++ b/src/yt_dlp.gd
@@ -3,7 +3,7 @@ extends Node
 signal setup_completed
 signal _update_completed
 
-enum Video {MP4, WEBM}
+enum Video {MP4, WEBM, OGV}
 enum Audio {AAC, FLAC, MP3, M4A, OPUS, VORBIS, WAV}
 
 const Downloader = preload("res://addons/godot-yt-dlp/src/downloader.gd")
@@ -94,6 +94,7 @@ class Download extends RefCounted:
 	var _destination: String = "user://"
 	var _file_name: String = "godot_yt_dlp_download_"
 	var _convert_to_audio: bool = false
+	var _convert_to_video: bool = false
 	var _video_format: Video = Video.WEBM
 	var _audio_format: Audio = Audio.MP3
 	
@@ -122,6 +123,11 @@ class Download extends RefCounted:
 		_audio_format = format
 		_convert_to_audio = true
 		return self
+		
+	func convert_to_video(format: Video) -> Download:
+		_video_format = format
+		_convert_to_video = true
+		return self
 	
 	
 	func get_status() -> Status:
@@ -148,14 +154,15 @@ class Download extends RefCounted:
 		
 		var options_and_arguments: Array = []
 		
+		var format: String
 		if _convert_to_audio:
-			var format: String = (Audio.keys()[_audio_format] as String).to_lower()
+			format = (Audio.keys()[_audio_format] as String).to_lower()
 			options_and_arguments.append_array(["-x", "--audio-format", format])
 		else:
-			var format: String
-			
 			match _video_format:
 				Video.WEBM:
+					format = "bestvideo[ext=webm]+bestaudio"
+				Video.OGV:
 					format = "bestvideo[ext=webm]+bestaudio"
 				Video.MP4:
 					format = "bestvideo[ext=mp4]+m4a"
@@ -172,6 +179,25 @@ class Download extends RefCounted:
 		
 		var output: Array = []
 		OS.execute(executable, PackedStringArray(options_and_arguments), output)
+		
+		if _convert_to_video && _video_format == Video.OGV:
+			var source_video_file_path: String = "{destination}{file_name}.{ext}" \
+				.format({
+					"destination": _destination,
+					"file_name": _file_name,
+					"ext": "webm"
+				})
+			
+			var target_video_file_path: String = "{destination}{file_name}.{ext}" \
+				.format({
+					"destination": _destination,
+					"file_name": _file_name,
+					"ext": (Video.keys()[_video_format] as String).to_lower()
+				})
+			var ffmpeg_path: String = ProjectSettings.globalize_path("user://ffmpeg.exe")
+			
+			#convert with settings recommended by https://docs.godotengine.org/en/stable/tutorials/animation/playing_videos.html#doc-playing-videos-recommended-theora-encoding-settings
+			OS.execute(ffmpeg_path, ["-i", source_video_file_path, "-q:v", "6", "-q:a", "6", target_video_file_path], output, true)
 		
 		self._thread_finished.call_deferred()
 	


### PR DESCRIPTION
I implemented a workflow for playing a video in Godot. 
This currently downloads the video and converts it with ffmpeg to ogv, so Godot can play it back. This widly inefficient in both conversion speed and in filesize, but it's the only officially supported way of Godot right now. So as long as https://github.com/godotengine/godot-proposals/issues/3286 doesn't finally offer a better support of more common codecs and containers, this seems to be the only way.
I've added an example and wrote a disclaimer for this solution.